### PR TITLE
EntityProxyを再生成するように修正

### DIFF
--- a/Resource/template/admin/check_plugin_vesrion.twig
+++ b/Resource/template/admin/check_plugin_vesrion.twig
@@ -17,11 +17,11 @@
                 <div class="card rounded border-0 mb-4">
                     {% if is_ok %}
                         <div class="card-header">
-                            <span>インストール済のプラグインはEC-CUBE4.0.2に対応しています</span>
+                            <span>インストール済のプラグインはEC-CUBE{{ constant('Plugin\\EccubeUpdater402to403\\Common\\Constant::TO_VERSION') }}に対応しています</span>
                         </div>
                     {% else %}
                         <div class="card-header">
-                            <span>以下の{{ unSupportedPlugins|length }}プラグインはEC-CUBE4.0.2に対応していません。プラグインが動作しない可能性があります。</span>
+                            <span>以下の{{ unSupportedPlugins|length }}プラグインはEC-CUBE{{ constant('Plugin\\EccubeUpdater402to403\\Common\\Constant::TO_VERSION') }}に対応していません。プラグインが動作しない可能性があります。</span>
                         </div>
                         <div class="card-body">
                             <div class="row">

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/EccubeUpdater402to403",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "EC-CUBEアップデートプラグイン",
   "type": "eccube-plugin",
   "require": {


### PR DESCRIPTION
https://github.com/EC-CUBE/ec-cube/pull/4117 により、EntityProxyの設置パスが変更されたため、アップデートプラグイン実行後にシステムエラーが発生する不具合を修正

EntityProxyを再生成するように修正しています。