### PR TITLE
初期インストールプラグインのアップデートはスキップ

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -330,7 +330,6 @@ class ConfigController extends AbstractController
             'eccube:generate:proxies',
             'doctrine:schema:update --dump-sql -f',
             'doctrine:migrations:migrate --no-interaction',
-            'eccube:update411to412:update-pre-install-plugins',
             'cache:clear --no-warmup',
             'cache:warmup --no-optional-warmers',
             'eccube:update411to412:dump-autoload',

--- a/Resource/template/admin/complete.twig
+++ b/Resource/template/admin/complete.twig
@@ -21,6 +21,15 @@
                         <span><a href="{{ url('admin_setting_system_system') }}">システム情報</a>でバージョンを確認することができます。</span>
                     </div>
                 </div>
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-header">
+                        <span>プラグインのアップデートをご確認ください。</span>
+                    </div>
+                    <div class="card-body">
+                        <span>アップデートプラグインでは、インストールされているプラグインのアップデートは行われません。<br><a href="{{ url('admin_store_plugin') }}">プラグイン一覧</a>からプラグインのアップデートをご確認ください。</span>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>

--- a/Resource/template/admin/complete.twig
+++ b/Resource/template/admin/complete.twig
@@ -29,7 +29,14 @@
                         <span>アップデートプラグインでは、インストールされているプラグインのアップデートは行われません。<br><a href="{{ url('admin_store_plugin') }}">プラグイン一覧</a>からプラグインのアップデートをご確認ください。</span>
                     </div>
                 </div>
-
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-header">
+                        <span>TRUSTED_HOSTSの設定を行ってください。</span>
+                    </div>
+                    <div class="card-body">
+                        <span><a href="https://www.ec-cube.net/info/weakness/weakness.php?id=83" target="_blank" rel="noreferrer">EC-CUBE 4系における HTTP Hostヘッダの処理に脆弱性 (JVN#53871926)</a>を参考に、<a href="{{ url('admin_setting_system_security') }}">セキュリティ管理</a>から「信頼できるHOST名」の設定を行ってください。</span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -21,9 +21,10 @@
                         <div class="row">
                             <div class="col mb-2">
                                 <ul>
-                                    <li>・この手順では、www.ec-cube.netからダウンロードしたEC-CUBEのパッケージを利用していることを想定しています。</li>
+                                    <li>・アップデートプラグインは、www.ec-cube.netからダウンロードしたEC-CUBEのパッケージを利用していることを想定しています。</li>
                                     <li>・本番環境でバージョンアップを行う前に、<strong class="text-danger">必ずテスト環境で事前検証を行ってください。</strong></li>
                                     <li>・本番環境でバージョンアップを行う前に、<strong class="text-danger">必ずファイルおよびデータベースのバックアップを行ってください。</strong></li>
+                                    <li>・アップデートプラグインではインストールされているプラグインのアップデートは行われません。<a href="{{ url('admin_store_plugin') }}">プラグイン一覧</a>からプラグインのアップデートををご確認ください。</strong></li>
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
初期インストールプラグインのアップデートが以下の箇所で行われるが、dtb_plugin.versionの更新が行われず、プラグイン一覧で「アップデート」ボタンが表示される。

https://github.com/EC-CUBE/eccube-update-plugin/pull/24/files#diff-dbee1ce106873a48e3d81715696fb4b6171f8df7e9dea09294b466840c1157a3L333

初期インストールプラグインのアップデートは行わず、ユーザが手動でアップデートしてもらうように変更する。
