### PR TITLE
Version表記の変更とAction用のイメージを修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   deploy:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/eccubeupdater406to410",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "EC-CUBEアップデートプラグイン",
   "type": "eccube-plugin",
   "require": {


### PR DESCRIPTION
p2/p3対応の追加修正
https://github.com/EC-CUBE/eccube-update-plugin/pull/34

* composer.jsonのバージョン表記変更 → 1.0.1へ
* GithubActionのイメージファイルを変更 → ubuntu-22.04